### PR TITLE
The nightly build workflow tries and upload builds nightly.

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -8,6 +8,7 @@ on:
 jobs:
 
   build:
+    if: github.repository_owner == 'aws'
     name: Upload Nightly Binaries
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Description of the issue
The github action, Nightly build, runs on forked repositories unless all workflows are disabled.

`Run jakejarvis/s3-sync-action@master
/usr/bin/docker run --name d[1](https://github.com/Cloudzero/amazon-cloudwatch-agent/runs/6564890057?check_suite_focus=true#step:7:1)105695f53b24be3a118f[13](https://github.com/Cloudzero/amazon-cloudwatch-agent/runs/6564890057?check_suite_focus=true#step:7:14)1b4f9ba9c_846c1b --label 08450d --workdir /github/workspace --rm -e GOROOT -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_REGION -e AWS_S3_BUCKET -e SOURCE_DIR -e DEST_DIR -e INPUT_ARGS -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_RUN_ATTEMPT -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_REF_NAME -e GITHUB_REF_PROTECTED -e GITHUB_REF_TYPE -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e GITHUB_STEP_SUMMARY -e RUNNER_OS -e RUNNER_ARCH -e RUNNER_NAME -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/amazon-cloudwatch-agent/amazon-cloudwatch-agent":"/github/workspace" 08450d:1105695f53b24be3a118f131b4f9ba9c --acl public-read
AWS_ACCESS_KEY_ID is not set. Quitting.`

# Description of changes
This change will test if the workflow is running from the aws repository.  If it is it will continue as normal.  But on forked repository it will run and exit early.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests


# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




