### PR TITLE
Cloudzero reduce log events

### DIFF
--- a/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
+++ b/plugins/outputs/cloudwatchlogs/cloudwatchlogs.go
@@ -139,6 +139,13 @@ func (c *CloudWatchLogs) writeMetricAsStructuredLog(m telegraf.Metric) {
 	cwd.switchToEMF()
 	cwd.pusher.RetryDuration = metricRetryTimeout
 
+	// CloudZero - The CloudZero Platform only processes the "Pod" Metrics.
+	// Filter out non-Pod Metrics
+	metricType := m.Tags()["Type"]
+	if !(metricType == "Pod") {
+		return
+	}
+
 	e := c.getLogEventFromMetric(m)
 	if e == nil {
 		return

--- a/plugins/processors/k8sdecorator/k8sdecorator.go
+++ b/plugins/processors/k8sdecorator/k8sdecorator.go
@@ -53,7 +53,8 @@ OUTER:
 		}
 		structuredlogsadapter.AddKubernetesInfo(metric, kubernetesBlob)
 		structuredlogsadapter.TagMetricSource(metric)
-		structuredlogsadapter.TagMetricRule(metric)
+		// CloudZero remove Custom Metrics
+		//structuredlogsadapter.TagMetricRule(metric)
 		structuredlogsadapter.TagLogGroup(metric)
 		metric.AddTag(logscommon.LogStreamNameTag, k.NodeName)
 		out = append(out, metric)


### PR DESCRIPTION
# Description of the issue
The performance log groups is expensive when there are many pod (500,000).

# Description of changes
The CloudZero platform only process metrics for the pods.  All other metric are ignore.  Filter out all metrics that are sent to the log except for pod metrics.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.






