### PR TITLE
Deployment Tracking

### DIFF
--- a/internal/k8sCommon/k8sclient/clientset.go
+++ b/internal/k8sCommon/k8sclient/clientset.go
@@ -68,7 +68,7 @@ func (c *K8sClient) init() {
 	c.Pod = new(podClient)
 	c.Node = new(nodeClient)
 	// CloudZero replicasets produce high memory consumption when there are large number of replicSets e.g. 71,000
-	//c.ReplicaSet = new(replicaSetClient)
+	c.ReplicaSet = new(replicaSetClient)
 	c.inited = true
 }
 

--- a/internal/k8sCommon/k8sclient/obj_store.go
+++ b/internal/k8sCommon/k8sclient/obj_store.go
@@ -53,6 +53,14 @@ func (s *ObjStore) Add(obj interface{}) error {
 		return err
 	}
 
+	// CloudZero - Allow ignoring Replicaset with zero active pods.
+	// Handle a nil return
+	if toCacheObj == nil {
+		// Nothing to to add to cache
+		log.Printf("I! ignoring update obj")
+		return nil
+	}
+
 	s.Lock()
 	defer s.Unlock()
 

--- a/internal/k8sCommon/k8sclient/replicaset.go
+++ b/internal/k8sCommon/k8sclient/replicaset.go
@@ -133,6 +133,11 @@ func transformFuncReplicaSet(obj interface{}) (interface{}, error) {
 	if !ok {
 		return nil, errors.New(fmt.Sprintf("input obj %v is not ReplicaSet type", obj))
 	}
+	// CloudZero, only track ReplicaSet that manage Pods
+	// refresh will pick up changes.  e.g. a Deployment rollback
+	if replicaSet.Status.Replicas == 0 {
+		return nil, nil
+	}
 	info := new(replicaSetInfo)
 	info.name = replicaSet.Name
 	info.owners = []*replicaSetOwner{}


### PR DESCRIPTION
Pod were not being rolled up to the owner of kind Deployments.

# Description of the issue
For performance reason the caching of ReplicaSet was turned off.  This prevented Pod Metric
being rolled up through ReplicaSet to the Deployment that owned that ReplicaSet. This change replace caching the ReplicaSet to support that lookup but it was modified to only cache ReplicaSet that are actively managing Pod.  This greatly reduced the number of Replicaset to track.
Here are some real work examples listing ReplicaSet with and without active Pods
Customer A
kubectl get rs --no-headers --all-namespaces | wc -l | awk {'print "Total RS = "$1'} && kubectl get rs --no-headers --all-namespaces | awk '$3!=0' | wc -l | awk {'print "non-zero RS = "$1'}
Total RS = 17918
non-zero RS = 1328

Customer B
Total RS = 7179
non-zero RS = 1730

# Description of changes
Only cache ReplicSet that are actively managing pods as ReplicaSet
not managing pod will never need to be looked up.

Here are some real work examples listing ReplicaSet with and without active Pods
Customer A
kubectl get rs --no-headers --all-namespaces | wc -l | awk {'print "Total RS = "$1'} && kubectl get rs --no-headers --all-namespaces | awk '$3!=0' | wc -l | awk {'print "non-zero RS = "$1'}
Total RS = 17918
non-zero RS = 1328

Customer B
Total RS = 7179
non-zero RS = 1730

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
load tested on a 150 node system.






