### PR TITLE
Cto 438 k8s agent replicaset tracking option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ DARWIN_BUILD_ARM64 = GO111MODULE=on GOOS=darwin GOARCH=arm64 go build -ldflags="
 
 IMAGE = amazon/cloudwatch-agent:$(VERSION)
 DOCKER_BUILD_FROM_SOURCE = docker build -t $(IMAGE) -f ./amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/source/Dockerfile
+DOCKER_BUILD_FROM_SOURCE_ARM64 = docker buildx build --platform linux/arm64 --push  -t $(IMAGE) -f ./amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/source/Dockerfile
+DOCKER_BUILD_FROM_SOURCE_AMD64 = docker buildx build --platform linux/amd64 --push  -t $(IMAGE) -f ./amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/source/Dockerfile
 
 CW_AGENT_IMPORT_PATH=https://github.com/aws/amazon-cloudwatch-agent.git
 ALL_SRC := $(shell find . -name '*.go' -type f | sort)
@@ -251,6 +253,12 @@ package-darwin: package-prepare-darwin-tar
 dockerized-build:
 	$(DOCKER_BUILD_FROM_SOURCE) .
 	@echo Built image:
+	@echo $(IMAGE)
+
+.PHONY: dockerized-build-amd64 dockerized-build-vendor
+dockerized-build-amd64:
+	$(DOCKER_BUILD_FROM_SOURCE_AMD64) .
+	@echo Built amd64 image:
 	@echo $(IMAGE)
 
 # Use vendor instead of proxy when building w/ vendor folder

--- a/amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/source/Dockerfile
+++ b/amazon-cloudwatch-container-insights/cloudwatch-agent-dockerfile/source/Dockerfile
@@ -1,3 +1,5 @@
+# syntax = docker/dockerfile:1.2
+
 # Build the binary
 ARG GO_IMAGE=golang:latest
 ARG CERT_IMAGE=ubuntu:latest
@@ -12,14 +14,17 @@ ENV GO111MODULE=${GO111MODULE}
 
 COPY go.mod /go/src/github.com/aws/amazon-cloudwatch-agent/
 COPY go.sum /go/src/github.com/aws/amazon-cloudwatch-agent/
-RUN go mod download -x
+RUN --mount=type=cache,target=/go/pkg/mod \
+ go mod download -x
 
 # NOTE: This arg will be populated by docker buildx
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 ARG TARGETARCH
 
 COPY . /go/src/github.com/aws/amazon-cloudwatch-agent/
-RUN make build-for-docker-${TARGETARCH}
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    make build-for-docker-${TARGETARCH}
 
 # Install cert and binaries
 FROM $CERT_IMAGE as cert
@@ -28,7 +33,8 @@ FROM $CERT_IMAGE as cert
 ARG TARGETARCH
 RUN mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
 RUN mkdir -p /opt/aws/amazon-cloudwatch-agent/var
-RUN apt-get update &&  \
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update &&  \
     apt-get install -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=builder /go/src/github.com/aws/amazon-cloudwatch-agent/build/bin/linux_${TARGETARCH}/ /opt/aws/amazon-cloudwatch-agent/bin

--- a/internal/k8sCommon/k8sclient/clientset.go
+++ b/internal/k8sCommon/k8sclient/clientset.go
@@ -68,7 +68,17 @@ func (c *K8sClient) init() {
 	c.Pod = new(podClient)
 	c.Node = new(nodeClient)
 	// CloudZero replicasets produce high memory consumption when there are large number of replicSets e.g. 71,000
-	c.ReplicaSet = new(replicaSetClient)
+	c.ReplicaSet = nil
+	var TrackRS = os.Getenv("TRACK_REPLICA_SETS")
+	log.Printf("D! TraceRS is %v", TrackRS)
+	if TrackRS == "True" || TrackRS == "true" {
+		log.Printf("D! Tracking ReplicaSets is True")
+		c.ReplicaSet = new(replicaSetClient)
+	} else if !(TrackRS == "False" || TrackRS == "false") {
+		log.Printf("E! Environment Variable TrackRS set to unknown value %v", TrackRS)
+		log.Printf("D! Tracking ReplicaSets is True as default")
+		c.ReplicaSet = new(replicaSetClient)
+	}
 	c.inited = true
 }
 

--- a/internal/k8sCommon/k8sclient/clientset.go
+++ b/internal/k8sCommon/k8sclient/clientset.go
@@ -77,7 +77,7 @@ func (c *K8sClient) init() {
 	} else if TrackRS == "False" || TrackRS == "false" {
 		log.Printf("I! CloudZero Tracking ReplicaSets is False.  Not tracking ReplicaSets")
 	} else {
-		log.Printf("I! CloudZero Environment Variable TrackRS set to unknown value %v", TrackRS)
+		log.Printf("I! CloudZero Environment Variable TrackRS set to unknown value [%v]", TrackRS)
 		log.Printf("I! CloudZero Tracking ReplicaSets is True as default")
 		c.ReplicaSet = new(replicaSetClient)
 	}

--- a/internal/k8sCommon/k8sclient/clientset.go
+++ b/internal/k8sCommon/k8sclient/clientset.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 
@@ -70,16 +71,13 @@ func (c *K8sClient) init() {
 	// CloudZero replicasets produce high memory consumption when there are large number of replicSets e.g. 71,000
 	c.ReplicaSet = nil
 	var TrackRS = os.Getenv("TRACK_REPLICA_SETS")
-	log.Printf("D! CloudZero TraceRS is %v", TrackRS)
-	if TrackRS == "True" || TrackRS == "true" {
-		log.Printf("I! CloudZero Tracking ReplicaSets is True")
+	log.Printf("I! CloudZero TrackRS is %v", TrackRS)
+	setTrackRS, err := strconv.ParseBool(TrackRS)
+	if err != nil || setTrackRS == true {
+		log.Printf("I! CloudZero Tracking ReplicaSets is True: %v", TrackRS)
 		c.ReplicaSet = new(replicaSetClient)
-	} else if TrackRS == "False" || TrackRS == "false" {
-		log.Printf("I! CloudZero Tracking ReplicaSets is False.  Not tracking ReplicaSets")
 	} else {
-		log.Printf("I! CloudZero Environment Variable TrackRS set to unknown value [%v]", TrackRS)
-		log.Printf("I! CloudZero Tracking ReplicaSets is True as default")
-		c.ReplicaSet = new(replicaSetClient)
+		log.Printf("I! CloudZero Tracking ReplicaSets is False.  Not tracking ReplicaSets")
 	}
 	c.inited = true
 }

--- a/internal/k8sCommon/k8sclient/clientset.go
+++ b/internal/k8sCommon/k8sclient/clientset.go
@@ -74,7 +74,9 @@ func (c *K8sClient) init() {
 	if TrackRS == "True" || TrackRS == "true" {
 		log.Printf("I! CloudZero Tracking ReplicaSets is True")
 		c.ReplicaSet = new(replicaSetClient)
-	} else if !(TrackRS == "False" || TrackRS == "false") {
+	} else if TrackRS == "False" || TrackRS == "false" {
+		log.Printf("I! CloudZero Tracking ReplicaSets is False.  Not tracking ReplicaSets")
+	} else {
 		log.Printf("I! CloudZero Environment Variable TrackRS set to unknown value %v", TrackRS)
 		log.Printf("I! CloudZero Tracking ReplicaSets is True as default")
 		c.ReplicaSet = new(replicaSetClient)

--- a/internal/k8sCommon/k8sclient/clientset.go
+++ b/internal/k8sCommon/k8sclient/clientset.go
@@ -70,13 +70,13 @@ func (c *K8sClient) init() {
 	// CloudZero replicasets produce high memory consumption when there are large number of replicSets e.g. 71,000
 	c.ReplicaSet = nil
 	var TrackRS = os.Getenv("TRACK_REPLICA_SETS")
-	log.Printf("D! TraceRS is %v", TrackRS)
+	log.Printf("D! CloudZero TraceRS is %v", TrackRS)
 	if TrackRS == "True" || TrackRS == "true" {
-		log.Printf("D! Tracking ReplicaSets is True")
+		log.Printf("I! CloudZero Tracking ReplicaSets is True")
 		c.ReplicaSet = new(replicaSetClient)
 	} else if !(TrackRS == "False" || TrackRS == "false") {
-		log.Printf("E! Environment Variable TrackRS set to unknown value %v", TrackRS)
-		log.Printf("D! Tracking ReplicaSets is True as default")
+		log.Printf("I! CloudZero Environment Variable TrackRS set to unknown value %v", TrackRS)
+		log.Printf("I! CloudZero Tracking ReplicaSets is True as default")
 		c.ReplicaSet = new(replicaSetClient)
 	}
 	c.inited = true

--- a/internal/k8sCommon/k8sclient/obj_store.go
+++ b/internal/k8sCommon/k8sclient/obj_store.go
@@ -57,7 +57,7 @@ func (s *ObjStore) Add(obj interface{}) error {
 	// Handle a nil return
 	if toCacheObj == nil {
 		// Nothing to to add to cache
-		log.Printf("I! ignoring update obj")
+		// log.Printf("I! ignoring update obj")
 		return nil
 	}
 


### PR DESCRIPTION
# Description of the issue
The agent on extremely large Clusters containing many ReplicaSets might have high memory usage

# Description of changes
Made mapping replicaSet to the ownering Deployment an option.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Tested on a Cluster with version 1.22 of Kubernetes and modified the values of a new environment variable






