### PR TITLE
[CP-7738] attempt to publish the workload name of a pod

### DIFF
--- a/internal/containerinsightscommon/k8sconst.go
+++ b/internal/containerinsightscommon/k8sconst.go
@@ -12,6 +12,7 @@ const (
 	Kubernetes       = "kubernetes"
 	K8sNamespace     = "Namespace"
 	PodIdKey         = "PodId"
+	WorkloadNameKey  = "WorkloadName"
 	PodNameKey       = "PodName"
 	K8sPodNameKey    = "K8sPodName"
 	ContainerNamekey = "ContainerName"


### PR DESCRIPTION
# Description of the issue
Currently, the `addPodOwnersAndPodName` method attempts to find the "pod name" of from the `OwnerReferences` attribute of a pod and sets the `PodName` tag accordingly. If the pod is from a statefulset, the `PodName` is set as the actual pod name. If the pod is from some other type of workload resource, `PodName` is set to the name of that workload resource. If the pod is from `kube-proxy`, that `PodName` is set to "kube-proxy". if no name can be found from previous conditions, the `PodName` is set to the `Name` attribute of the pod.

The issues with this is that setting `PodName` to the name of the workload resource that controls it is inaccurate. It is also inconsistent, because statefulset pods are set to the name of the statefulset pod.

# Description of changes
This PR alters this method to instead set a new tag, `WorkloadName`, and removes the special case for statefulsets.  This means that a `WorkloadName` and `PodName` tags will exist. `WorkloadName` should be the name of the workload resource from the pod, or an empty string if it cannot be determined. `podName` should be the actual name of the pod.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
Updated existing unit tests to expect the WorkloadName tag instead of PodName. Some existing and unrelated tests are failing

# Requirements
_Before commit the code, please do the following steps._
1. Run `make fmt` and `make fmt-sh`
2. Run `make linter`




